### PR TITLE
Allow slots run over end of range

### DIFF
--- a/lib/slotty.rb
+++ b/lib/slotty.rb
@@ -10,7 +10,7 @@ module Slotty
   InvalidExclusionError = Class.new(StandardError)
 
   class << self
-    def get_slots(for_range:, slot_length_mins:, interval_mins:, as: :full, exclude_times: [])
+    def get_slots(for_range:, slot_length_mins:, interval_mins:, as: :full, exclude_times: [], allow_slot_run_over: false)
       raise InvalidDateError, "for_value must be type of Range" unless for_range.is_a?(Range)
       raise InvalidSlotLengthError, "slot_length_mins must be an integer" unless slot_length_mins.is_a?(Integer)
       raise InvalidIntervalError, "interval_mins must be an integer" unless interval_mins.is_a?(Integer)
@@ -23,7 +23,7 @@ module Slotty
 
       potential_slot = Slot.new(range: for_range.begin..(for_range.begin + slot_length))
 
-      while Timeframe.covers?(for_range, potential_slot)
+      while Timeframe.covers?(for_range, potential_slot) || (allow_slot_run_over && Timeframe.starts_within?(for_range, potential_slot))
         if potential_slot.has_overlaps?(exclude_times)
           potential_slot = Slot.new(range: (potential_slot.begin + interval)..(potential_slot.begin + interval + slot_length))
 

--- a/lib/slotty/timeframe.rb
+++ b/lib/slotty/timeframe.rb
@@ -9,10 +9,15 @@ module Slotty
       end
 
       def contains?(excluder, potential_slot)
-        start_within = potential_slot.begin >= excluder.begin && potential_slot.begin < excluder.end
-        end_within = potential_slot.end > excluder.begin && potential_slot.end <= excluder.end
+        starts_within?(excluder, potential_slot) || ends_within?(excluder, potential_slot)
+      end
 
-        start_within || end_within
+      def starts_within?(excluder, potential_slot)
+        potential_slot.begin >= excluder.begin && potential_slot.begin < excluder.end
+      end
+
+      def ends_within?(excluder, potential_slot)
+        potential_slot.end > excluder.begin && potential_slot.end <= excluder.end
       end
     end
   end

--- a/spec/slotty_spec.rb
+++ b/spec/slotty_spec.rb
@@ -155,5 +155,49 @@ RSpec.describe Slotty do
     expect { Slotty.get_slots({ for_range: Time.now..(Time.now + 60 * 60), slot_length_mins: 3, interval_mins: 3, exclude_times: 2 }) }.to raise_error(Slotty::InvalidExclusionError, "exclude_times must be an array of time ranges")
     expect { Slotty.get_slots({ for_range: Time.now..(Time.now + 60 * 60), slot_length_mins: 3, interval_mins: 3, exclude_times: [], as: :wrong }) }.to raise_error(Slotty::InvalidFormatError, "cannot format slot in this way")
   end
+
+  it "relevants slots even if slot runs over the end" do
+    attributes = {
+      for_range: Time.new(2020, 05, 01, 8, 00)..Time.new(2020, 05, 01, 9, 30),
+      slot_length_mins: 60,
+      interval_mins: 15,
+      allow_slot_run_over: true,
+    }
+
+    expected_slots = [
+      {
+        start_time: Time.new(2020, 05, 01, 8, 00),
+        end_time: Time.new(2020, 05, 01, 9, 00),
+        time: "08:00 AM"
+      },
+      {
+        start_time: Time.new(2020, 05, 01, 8, 15),
+        end_time: Time.new(2020, 05, 01, 9, 15),
+        time: "08:15 AM"
+      },
+      {
+        start_time: Time.new(2020, 05, 01, 8, 30),
+        end_time: Time.new(2020, 05, 01, 9, 30),
+        time: "08:30 AM"
+      },
+      {
+        start_time: Time.new(2020, 05, 01, 8, 45),
+        end_time: Time.new(2020, 05, 01, 9, 45),
+        time: "08:45 AM"
+      },
+      {
+        start_time: Time.new(2020, 05, 01, 9, 00),
+        end_time: Time.new(2020, 05, 01, 10, 00),
+        time: "09:00 AM"
+      },
+      {
+        start_time: Time.new(2020, 05, 01, 9, 15),
+        end_time: Time.new(2020, 05, 01, 10, 15),
+        time: "09:15 AM"
+      },
+    ]
+
+    expect(Slotty.get_slots(attributes)).to eq(expected_slots)
+  end
 end
 


### PR DESCRIPTION
This is useful for when slot lenght and interval is the same and
we do not care if slots bleed past the end of the range.